### PR TITLE
Fix for namespaced module names that appear as dupes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 
 node_js:
-- '8'
+- '10'
+- '12'
 
 before_install:
 - cd test/fixtures/test-module && npm install && cd ../../..

--- a/index.js
+++ b/index.js
@@ -27,7 +27,9 @@ const npmList = (module) => {
  *
  */
 const testModule = (module) => {
-  const match = module.stdout.match(new RegExp(module.name + '@','g'));
+  // match the module name with a space prefixed so that namespaced
+  // packages of the same name will not count against the duplication check
+  const match = module.stdout.match(new RegExp(' ' + module.name + '@','g'));
   const dedupeMatch = module.stdout.match(new RegExp('deduped','g'));
 
   let duplicates = true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,27 +1,30 @@
 {
   "name": "@mapbox/duplicate-module-test",
-  "version": "0.1.0-alpha2",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "deep-equal": {
       "version": "1.0.1",
@@ -35,8 +38,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "defined": {
@@ -51,11 +54,11 @@
       "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -64,9 +67,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "for-each": {
@@ -75,7 +78,7 @@
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.3"
+        "is-callable": "^1.1.3"
       }
     },
     "foreach": {
@@ -87,7 +90,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -99,13 +103,14 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "has": {
@@ -114,22 +119,24 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "is-callable": {
       "version": "1.1.3",
@@ -149,7 +156,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.3"
+        "has": "^1.0.1"
       }
     },
     "is-symbol": {
@@ -162,8 +169,9 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -187,14 +195,16 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.5",
@@ -208,7 +218,7 @@
       "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resumer": {
@@ -217,15 +227,7 @@
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
-      }
-    },
-    "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "requires": {
-        "glob": "7.1.2"
+        "through": "~2.3.4"
       }
     },
     "string.prototype.trim": {
@@ -234,9 +236,9 @@
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.12.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
       }
     },
     "tape": {
@@ -245,19 +247,19 @@
       "integrity": "sha512-6fKIXknLpoe/Jp4rzHKFPpJUHDHDqn8jus99IfPnHIjyz78HYlefTGD3b5EkbQzuLfaEvmfPK3IolLgq2xT3kw==",
       "dev": true,
       "requires": {
-        "deep-equal": "1.0.1",
-        "defined": "1.0.0",
-        "for-each": "0.3.3",
-        "function-bind": "1.1.1",
-        "glob": "7.1.2",
-        "has": "1.0.3",
-        "inherits": "2.0.3",
-        "minimist": "1.2.0",
-        "object-inspect": "1.6.0",
-        "resolve": "1.7.1",
-        "resumer": "0.0.0",
-        "string.prototype.trim": "1.1.2",
-        "through": "2.3.8"
+        "deep-equal": "~1.0.1",
+        "defined": "~1.0.0",
+        "for-each": "~0.3.3",
+        "function-bind": "~1.1.1",
+        "glob": "~7.1.2",
+        "has": "~1.0.3",
+        "inherits": "~2.0.3",
+        "minimist": "~1.2.0",
+        "object-inspect": "~1.6.0",
+        "resolve": "~1.7.1",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.1.2",
+        "through": "~2.3.8"
       }
     },
     "through": {
@@ -269,7 +271,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     }
   }
 }

--- a/test/fixtures/npm-ls-namespaced-deduped
+++ b/test/fixtures/npm-ls-namespaced-deduped
@@ -1,0 +1,8 @@
+test@1.0.0 /Users/test/mapbox/duplicate-module-test/test
+├─┬ some-dependency@1.0.0
+│ └── test-module@5.0.0  deduped
+├─┬ @types/some-dependency@2.0.0
+│ └── test-module@5.0.0  deduped
+├── test-module@5.0.0 
+└─┬ dyno@1.4.1
+  └── test-module@5.0.0  deduped

--- a/test/fixtures/npm-ls-namespaced-dupes
+++ b/test/fixtures/npm-ls-namespaced-dupes
@@ -1,0 +1,8 @@
+test@1.0.0 /Users/test/mapbox/duplicate-module-test/test
+├─┬ some-dependency@1.0.0
+│ └── test-module@5.0.0
+├─┬ @types/some-dependency@2.0.0
+│ └── test-module@5.0.0
+├── test-module@5.0.0 
+└─┬ some-other-dependency@9.0.0
+  └── test-module@4.0.0

--- a/test/test.js
+++ b/test/test.js
@@ -76,7 +76,6 @@ test('cli', (assert) => {
     assert.ok(/✔ tape has only one version/.test(stdout));
   });
   exec(`cd ${__dirname}/fixtures/test-module && ${__dirname}/../bin/cli.js glob`, (err, stdout, stderr) => {
-    console.log(stdout)
     assert.ok(/✗ found duplicate versions of "glob" in 2 installs/.test(stdout), 'expected duplicates found');
   });
   assert.end();

--- a/test/test.js
+++ b/test/test.js
@@ -52,6 +52,20 @@ test('catch duplicates for new-school `npm ls` output which includes the "dedupe
   assert.end();
 });
 
+test('catch duplicates for when namespaced package has same base name', (assert) => {
+  const dupes = dmt.testModule({ name: 'test-module', stdout: fs.readFileSync(__dirname + '/fixtures/npm-ls-namespaced-dupes', 'utf-8') });
+  assert.ok(dupes.duplicates, 'found duplicates');
+  assert.equal(dupes.count, 4, 'found 4 duplicates');
+  assert.equal(dupes.name, 'test-module', 'has name');
+
+  const nodupes = dmt.testModule({ name: 'test-module', stdout: fs.readFileSync(__dirname + '/fixtures/npm-ls-namespaced-deduped', 'utf-8') });
+  assert.notOk(nodupes.duplicates, 'found no duplicates');
+  assert.equal(nodupes.count, 1, 'only one version installed');
+  assert.equal(nodupes.name, 'test-module', 'has name');
+
+  assert.end();
+});
+
 test('cli', (assert) => {
   exec(__dirname + '/../bin/cli.js does-not-exist', (err, stdout, stderr) => {
     assert.ok(/does-not-exist was not found in the node_modules tree/.test(stderr), 'expected output');
@@ -62,6 +76,7 @@ test('cli', (assert) => {
     assert.ok(/✔ tape has only one version/.test(stdout));
   });
   exec(`cd ${__dirname}/fixtures/test-module && ${__dirname}/../bin/cli.js glob`, (err, stdout, stderr) => {
+    console.log(stdout)
     assert.ok(/✗ found duplicate versions of "glob" in 2 installs/.test(stdout), 'expected duplicates found');
   });
   assert.end();


### PR DESCRIPTION
- Test on Node 10 and 12
- Remove support for Node 8
- Fixed a bug where a namespaced package with the same basename as the module under test would incorrectly cause `duplicate-module-test` to fail its check.
  - For example: `duplicate-module-test aws-sdk` would fail when `@types/aws-sdk` is also installed